### PR TITLE
Modify manifests for k8s-gsm-tools

### DIFF
--- a/config/prow/cluster/secretrotator-deployment.yaml
+++ b/config/prow/cluster/secretrotator-deployment.yaml
@@ -24,7 +24,7 @@ spec:
         image: gcr.io/k8s-staging-k8s-gsm-tools/secret-rotator:latest
         args:
         - --config-path=/tmp/config/rotConfig 
-        - --period=1000
+        - --period=60
         - --v=2
         volumeMounts:
         - name: config-volume

--- a/config/prow/cluster/secretsynccontroller-deployment.yaml
+++ b/config/prow/cluster/secretsynccontroller-deployment.yaml
@@ -24,7 +24,7 @@ spec:
         image: gcr.io/k8s-staging-k8s-gsm-tools/secret-sync-controller:latest
         args:
         - --config-path=/tmp/config/syncConfig 
-        - --period=1000
+        - --period=60
         - --v=2
         volumeMounts:
         - name: config-volume


### PR DESCRIPTION
Exceeded the quota for `read request per minute` to gsm by running rot and sync every second.

Set the default running period for secret-rotator and
secret-sync-controller to 60 seconds.
The new flags `period` for both are changed from using milliseconds to second.